### PR TITLE
fix: address Copilot suppressed sensor/docstring feedback

### DIFF
--- a/custom_components/pge_energy/sensor.py
+++ b/custom_components/pge_energy/sensor.py
@@ -129,18 +129,20 @@ def _sum_kwh(intervals: list[UsageInterval]) -> float | None:
 
 
 def _sum_return_kwh(intervals: list[UsageInterval]) -> float | None:
-    """Sum non-negative grid-export kWh from signed hourly intervals."""
+    """Sum non-negative grid-export kWh from signed hourly intervals.
+
+    Returns ``0`` when published intervals exist but none exported; ``None``
+    only when there is no usable kWh data in the range.
+    """
     total = 0.0
-    any_value = False
+    any_published = False
     for iv in intervals:
         if iv.kwh is None:
             continue
+        any_published = True
         split = split_signed_usage(iv.kwh, iv.amount, resolution=iv.resolution)
-        if split.return_kwh <= 0:
-            continue
-        any_value = True
         total += float(split.return_kwh)
-    return total if any_value else None
+    return total if any_published else None
 
 
 def _sum_cost(intervals: list[UsageInterval]) -> float | None:
@@ -158,17 +160,17 @@ def _sum_cost(intervals: list[UsageInterval]) -> float | None:
 
 
 def _sum_compensation(intervals: list[UsageInterval]) -> float | None:
+    """Sum export credits; ``0`` when amounts exist but none are credits."""
     total = 0.0
-    any_value = False
+    any_published = False
     for iv in intervals:
         if iv.kwh is None or iv.amount is None:
             continue
+        any_published = True
         split = split_signed_usage(iv.kwh, iv.amount, resolution=iv.resolution)
-        if split.compensation is None or split.compensation <= 0:
-            continue
-        any_value = True
-        total += float(split.compensation)
-    return total if any_value else None
+        if split.compensation is not None and split.compensation > 0:
+            total += float(split.compensation)
+    return total if any_published else None
 
 
 async def async_setup_entry(

--- a/custom_components/pge_energy/usage_direction.py
+++ b/custom_components/pge_energy/usage_direction.py
@@ -12,13 +12,15 @@ _ZERO = Decimal("0")
 
 @dataclass(frozen=True, slots=True)
 class DirectionalUsage:
-    """Non-negative directional components for one energy interval."""
+    """Non-negative directional components for one energy interval.
+
+    ``compensation`` is set only for hourly export credits; otherwise None.
+    """
 
     consumption: Decimal
     return_kwh: Decimal
     cost: Decimal | None
     compensation: Decimal | None
-    """Compensation is set only for hourly export credits; otherwise None."""
 
 
 def split_signed_usage(

--- a/tasks.md
+++ b/tasks.md
@@ -11,6 +11,7 @@
 - [x] Live HA UAT on `/pge`: sync complete, KPIs populated, frontend `?v=0.8.0`, export KPI hidden on non-generating account
 - [x] Address [#10](https://github.com/spencerthayer/homeassistant-pge/issues/10): Energy dashboard docs, stable `account_key`, clear external stats on entry remove
 - [ ] Ship MINOR HACS release `v0.8.0` only after explicit approval (release+tag for v0.8.0 withdrawn; Latest remains v0.7.5)
+- [x] Address Copilot suppressed feedback: return/compensation day sums report `0` (not unavailable) when published intervals have no export; fix `DirectionalUsage` field docstring
 
 ## Active agents
 

--- a/tests/components/pge_energy/test_sensor_helpers.py
+++ b/tests/components/pge_energy/test_sensor_helpers.py
@@ -18,8 +18,10 @@ from custom_components.pge_energy.sensor import (
     PGEHourlyCostSensor,
     PGEHourlyEnergySensor,
     _intervals_in_range,
+    _sum_compensation,
     _sum_cost,
     _sum_kwh,
+    _sum_return_kwh,
 )
 from custom_components.pge_energy.statistics import (
     _build_entity_consumption_metadata,
@@ -48,6 +50,24 @@ class TestDayHelpers:
         intervals = [_iv(0, 1.5, 0.3), _iv(1, 2.0, 0.4), _iv(2, 1.0, None)]
         assert _sum_kwh(intervals) == 4.5
         assert _sum_cost(intervals) == 0.7
+
+    def test_sum_return_and_compensation_zero_when_no_export(self):
+        """Published import-only hours report 0 export, not unavailable."""
+        intervals = [_iv(0, 1.5, 0.3), _iv(1, 2.0, 0.4)]
+        assert _sum_return_kwh(intervals) == 0.0
+        assert _sum_compensation(intervals) == 0.0
+
+    def test_sum_return_and_compensation_none_without_data(self):
+        assert _sum_return_kwh([]) is None
+        assert _sum_compensation([]) is None
+        assert _sum_return_kwh([_iv(0, 1.0, amount=None)]) == 0.0
+        # Compensation needs amount samples; kWh-only rows are not enough.
+        assert _sum_compensation([_iv(0, 1.0, amount=None)]) is None
+
+    def test_sum_return_and_compensation_export_hours(self):
+        intervals = [_iv(0, 2.0, 0.4), _iv(1, -1.5, -0.2)]
+        assert _sum_return_kwh(intervals) == 1.5
+        assert _sum_compensation(intervals) == 0.2
 
     def test_intervals_in_range(self):
         intervals = [_iv(0, 1.0, day=22), _iv(0, 2.0, day=23), _iv(1, 3.0, day=23)]


### PR DESCRIPTION
## Summary
- `_sum_return_kwh` / `_sum_compensation` return `0` when published intervals exist but none exported (non-generating accounts no longer show unavailable for Yesterday return/compensation).
- Move the stray `DirectionalUsage.compensation` triple-quoted string into the class docstring.
- Covers the three suppressed Copilot comments from PR #13 that were not open review threads.

## Test plan
- [x] Unit tests for zero vs None return/compensation sums
- [ ] CI green

No HACS release in this PR.
