### PR TITLE
Fix Sync settings Submit expected-float on blank TOD rates (v0.9.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PGE publishes usage **once overnight**, so a "stuck" latest interval near `01:00
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.9`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.10`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PGE publishes usage **once overnight**, so a "stuck" latest interval near `01:00
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.10`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `9.9.10`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PGE publishes usage **once overnight**, so a "stuck" latest interval near `01:00
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `9.9.10`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.10`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/custom_components/pge_energy/config_flow.py
+++ b/custom_components/pge_energy/config_flow.py
@@ -450,6 +450,22 @@ class PGEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
+class OptionalNumberSelector(NumberSelector):
+    """Number selector that treats blank/None as unset (returns None).
+
+    Bare ``NumberSelector`` raises ``expected float`` for empty OptionsFlow
+    boxes. Sync settings had four optional TOD rate fields that blocked Submit
+    whenever those boxes were left blank (the common case).
+    """
+
+    def __call__(self, data: Any) -> float | None:
+        if data is None:
+            return None
+        if isinstance(data, str) and not data.strip():
+            return None
+        return super().__call__(data)
+
+
 def _clean_tod_rate(raw: Any) -> float | None:
     """Coerce an optional TOD rate override; empty/unset/None → None."""
     if raw is None:
@@ -465,6 +481,19 @@ def _clean_tod_rate(raw: Any) -> float | None:
     if isinstance(raw, (int, float)) and raw > 0:
         return float(raw)
     return None
+
+
+def _optional_tod_rate_selector() -> OptionalNumberSelector:
+    """TOD rate override number box; blank keeps portal/default rates."""
+    return OptionalNumberSelector(
+        NumberSelectorConfig(
+            min=0.01,
+            max=10.0,
+            step="any",
+            mode=NumberSelectorMode.BOX,
+            unit_of_measurement="USD/kWh",
+        )
+    )
 
 
 def _options_schema(entry: config_entries.ConfigEntry) -> vol.Schema:
@@ -619,47 +648,19 @@ def _options_schema(entry: config_entries.ConfigEntry) -> vol.Schema:
             vol.Optional(
                 CONF_TOD_RATE_OFF_PEAK,
                 default=get_entry_option(entry, CONF_TOD_RATE_OFF_PEAK, None),
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=0.01,
-                    max=10.0,
-                    mode=NumberSelectorMode.BOX,
-                    unit_of_measurement="USD/kWh",
-                )
-            ),
+            ): _optional_tod_rate_selector(),
             vol.Optional(
                 CONF_TOD_RATE_MID_PEAK,
                 default=get_entry_option(entry, CONF_TOD_RATE_MID_PEAK, None),
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=0.01,
-                    max=10.0,
-                    mode=NumberSelectorMode.BOX,
-                    unit_of_measurement="USD/kWh",
-                )
-            ),
+            ): _optional_tod_rate_selector(),
             vol.Optional(
                 CONF_TOD_RATE_ON_PEAK,
                 default=get_entry_option(entry, CONF_TOD_RATE_ON_PEAK, None),
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=0.01,
-                    max=10.0,
-                    mode=NumberSelectorMode.BOX,
-                    unit_of_measurement="USD/kWh",
-                )
-            ),
+            ): _optional_tod_rate_selector(),
             vol.Optional(
                 CONF_TOD_RATE_BASIC_SERVICE,
                 default=get_entry_option(entry, CONF_TOD_RATE_BASIC_SERVICE, None),
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=0.01,
-                    max=10.0,
-                    mode=NumberSelectorMode.BOX,
-                    unit_of_measurement="USD/kWh",
-                )
-            ),
+            ): _optional_tod_rate_selector(),
         }
     )
 

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "0.9.9"
+VERSION = "0.9.10"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "9.9.10"
+VERSION = "0.9.10"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "0.9.10"
+VERSION = "9.9.10"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=9.9.10";
+} from "./data.js?v=0.9.10";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=9.9.10";
+} from "./theme.js?v=0.9.10";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=0.9.10";
+} from "./data.js?v=9.9.10";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=0.9.10";
+} from "./theme.js?v=9.9.10";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=0.9.9";
+} from "./data.js?v=0.9.10";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=0.9.9";
+} from "./theme.js?v=0.9.10";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -43,7 +43,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=0.9.9";
+} from "./data.js?v=0.9.10";
 import {
   createBarChart,
   createLineChart,
@@ -53,9 +53,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=0.9.9";
-import { sparklineSvg } from "./svg-helpers.js?v=0.9.9";
-import { applyPanelTheme } from "./theme.js?v=0.9.9";
+} from "./charts.js?v=0.9.10";
+import { sparklineSvg } from "./svg-helpers.js?v=0.9.10";
+import { applyPanelTheme } from "./theme.js?v=0.9.10";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -43,7 +43,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=9.9.10";
+} from "./data.js?v=0.9.10";
 import {
   createBarChart,
   createLineChart,
@@ -53,9 +53,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=9.9.10";
-import { sparklineSvg } from "./svg-helpers.js?v=9.9.10";
-import { applyPanelTheme } from "./theme.js?v=9.9.10";
+} from "./charts.js?v=0.9.10";
+import { sparklineSvg } from "./svg-helpers.js?v=0.9.10";
+import { applyPanelTheme } from "./theme.js?v=0.9.10";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -43,7 +43,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=0.9.10";
+} from "./data.js?v=9.9.10";
 import {
   createBarChart,
   createLineChart,
@@ -53,9 +53,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=0.9.10";
-import { sparklineSvg } from "./svg-helpers.js?v=0.9.10";
-import { applyPanelTheme } from "./theme.js?v=0.9.10";
+} from "./charts.js?v=9.9.10";
+import { sparklineSvg } from "./svg-helpers.js?v=9.9.10";
+import { applyPanelTheme } from "./theme.js?v=9.9.10";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/spencerthayer/homeassistant-pge/issues",
   "requirements": ["pypdf==6.14.2"],
-  "version": "9.9.10"
+  "version": "0.9.10"
 }

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/spencerthayer/homeassistant-pge/issues",
   "requirements": ["pypdf==6.14.2"],
-  "version": "0.9.9"
+  "version": "0.9.10"
 }

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/spencerthayer/homeassistant-pge/issues",
   "requirements": ["pypdf==6.14.2"],
-  "version": "0.9.10"
+  "version": "9.9.10"
 }

--- a/docs/HA_SETTINGS_HISTORY.md
+++ b/docs/HA_SETTINGS_HISTORY.md
@@ -22,6 +22,7 @@ Settings → Devices & Services → **Portland General Electric Energy Usage** �
 | Bill PDF retention (`bill_pdf_retention`) | `latest` | Binary file retention: `latest`, `all_imported`, or `rolling_n`. Normalized Store records and recorder history are kept independently. |
 | Bill PDF rolling count (`bill_pdf_rolling_count`) | `12` | When retention is `rolling_n`, keep this many newest statement PDF files. |
 | Backfill concurrency | `2` | Parallel day fetches during backfill. |
+| TOD rate overrides (`tod_rate_off_peak` / `_mid_peak` / `_on_peak` / `_basic_service`) | blank | Optional USD/kWh overrides. Leave blank to use last portal rate, then built-in defaults. Empty boxes must validate (blank is allowed — do not require a float). |
 
 PGE publishes usage **overnight**, not continuously. A daytime-stuck **Latest available interval** near ~01:00 Pacific is expected.
 

--- a/tasks.md
+++ b/tasks.md
@@ -31,6 +31,7 @@
 - [x] Copilot PR loop iter 12: program list eligibility/enrollment preserve null (tri-state) instead of coerced False
 - [x] Copilot PR loop iter 13: enroll parse/Store null round-trip; peak-hour import guard; PTR DATE; DST yesterday; positive-credit docs
 - [x] HITL merge PR #21 (`2dfb6a3`); HACS release [`v0.9.9`](https://github.com/spencerthayer/homeassistant-pge/releases/tag/v0.9.9); asked [@NinjaNife](https://github.com/NinjaNife) + [@spencerthayer](https://github.com/spencerthayer) to UAT on [#5](https://github.com/spencerthayer/homeassistant-pge/issues/5#issuecomment-5300448116)
+- [ ] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v0.9.10`
 
 ## Programs / net metering / TOD — v0.9.1
 

--- a/tasks.md
+++ b/tasks.md
@@ -31,7 +31,7 @@
 - [x] Copilot PR loop iter 12: program list eligibility/enrollment preserve null (tri-state) instead of coerced False
 - [x] Copilot PR loop iter 13: enroll parse/Store null round-trip; peak-hour import guard; PTR DATE; DST yesterday; positive-credit docs
 - [x] HITL merge PR #21 (`2dfb6a3`); HACS release [`v0.9.9`](https://github.com/spencerthayer/homeassistant-pge/releases/tag/v0.9.9); asked [@NinjaNife](https://github.com/NinjaNife) + [@spencerthayer](https://github.com/spencerthayer) to UAT on [#5](https://github.com/spencerthayer/homeassistant-pge/issues/5#issuecomment-5300448116)
-- [ ] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v9.9.10`
+- [ ] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v0.9.10`
 
 ## Programs / net metering / TOD — v0.9.1
 

--- a/tasks.md
+++ b/tasks.md
@@ -31,7 +31,7 @@
 - [x] Copilot PR loop iter 12: program list eligibility/enrollment preserve null (tri-state) instead of coerced False
 - [x] Copilot PR loop iter 13: enroll parse/Store null round-trip; peak-hour import guard; PTR DATE; DST yesterday; positive-credit docs
 - [x] HITL merge PR #21 (`2dfb6a3`); HACS release [`v0.9.9`](https://github.com/spencerthayer/homeassistant-pge/releases/tag/v0.9.9); asked [@NinjaNife](https://github.com/NinjaNife) + [@spencerthayer](https://github.com/spencerthayer) to UAT on [#5](https://github.com/spencerthayer/homeassistant-pge/issues/5#issuecomment-5300448116)
-- [ ] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v0.9.10`
+- [ ] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v9.9.10`
 
 ## Programs / net metering / TOD — v0.9.1
 

--- a/tests/components/pge_energy/test_config_flow.py
+++ b/tests/components/pge_energy/test_config_flow.py
@@ -22,8 +22,12 @@ from custom_components.pge_energy.const import (
     CONF_AUTO_BACKFILL,
     CONF_BACKFILL_CONCURRENCY,
     CONF_BEARER_TOKEN,
+    CONF_BILL_PDF_FORM,
+    CONF_BILL_PDF_RETENTION,
+    CONF_BILL_PDF_ROLLING_COUNT,
     CONF_CAPTURE_GRAPHQL_DIAGNOSTICS,
     CONF_CORRECTION_WINDOW,
+    CONF_DOWNLOAD_BILL_PDFS,
     CONF_EMAIL,
     CONF_HISTORY_MODE,
     CONF_HISTORY_START_DATE,
@@ -36,6 +40,10 @@ from custom_components.pge_energy.const import (
     CONF_POLLING_INTERVAL,
     CONF_POLLING_INTERVAL_UNIT,
     CONF_SYNC_LOCAL_TIME,
+    CONF_TOD_RATE_BASIC_SERVICE,
+    CONF_TOD_RATE_MID_PEAK,
+    CONF_TOD_RATE_OFF_PEAK,
+    CONF_TOD_RATE_ON_PEAK,
     DEFAULT_SYNC_LOCAL_TIME,
     MANUAL_SYNC_ACTION_REFRESH,
     HistoryMode,
@@ -245,6 +253,114 @@ class TestPGEOptionsFlow:
             field for field in schema.schema if getattr(field, "schema", field) == CONF_CAPTURE_GRAPHQL_DIAGNOSTICS
         )
         assert capture_field.default() is False
+
+    def test_options_schema_accepts_blank_tod_rate_overrides(self):
+        """Blank optional TOD NumberSelectors must not raise 'expected float'.
+
+        HA OptionsFlow submits empty number boxes as None (or sometimes ""), and
+        vol.Optional(..., default=None) also inserts None when the key is omitted.
+        Sync settings Submit must succeed so diagnostic capture and other options
+        can be saved (#5 comment).
+        """
+        entry = MagicMock()
+        entry.options = {}
+        entry.data = {}
+        schema = _options_schema(entry)
+        base = {
+            CONF_POLLING_INTERVAL: 4,
+            CONF_POLLING_INTERVAL_UNIT: PollingIntervalUnit.HOURS.value,
+            CONF_SYNC_LOCAL_TIME: DEFAULT_SYNC_LOCAL_TIME,
+            CONF_CORRECTION_WINDOW: 7,
+            CONF_HISTORY_MODE: HistoryMode.FULL.value,
+            CONF_HISTORY_START_DATE: "2019-01-01",
+            CONF_HOURLY_BACKFILL_DAYS: 90,
+            CONF_AUTO_BACKFILL: True,
+            CONF_INCLUDE_COST: True,
+            CONF_INCLUDE_DIAGNOSTICS: True,
+            CONF_CAPTURE_GRAPHQL_DIAGNOSTICS: True,
+            CONF_INCLUDE_BILLING: True,
+            CONF_DOWNLOAD_BILL_PDFS: False,
+            CONF_BILL_PDF_FORM: "detailed",
+            CONF_BILL_PDF_RETENTION: "latest",
+            CONF_BILL_PDF_ROLLING_COUNT: 12,
+            CONF_BACKFILL_CONCURRENCY: 2,
+        }
+
+        # Omitted keys (Optional defaults fill None, then must validate).
+        assert schema(dict(base))
+
+        for blank in (None, ""):
+            payload = dict(base)
+            payload.update(
+                {
+                    CONF_TOD_RATE_OFF_PEAK: blank,
+                    CONF_TOD_RATE_MID_PEAK: blank,
+                    CONF_TOD_RATE_ON_PEAK: blank,
+                    CONF_TOD_RATE_BASIC_SERVICE: blank,
+                }
+            )
+            validated = schema(payload)
+            assert validated[CONF_CAPTURE_GRAPHQL_DIAGNOSTICS] is True
+            assert validated[CONF_TOD_RATE_OFF_PEAK] in (None, "")
+            assert validated[CONF_TOD_RATE_MID_PEAK] in (None, "")
+            assert validated[CONF_TOD_RATE_ON_PEAK] in (None, "")
+            assert validated[CONF_TOD_RATE_BASIC_SERVICE] in (None, "")
+
+        with_rates = dict(base)
+        with_rates.update(
+            {
+                CONF_TOD_RATE_OFF_PEAK: 0.0893,
+                CONF_TOD_RATE_MID_PEAK: 0.167,
+                CONF_TOD_RATE_ON_PEAK: 0.4313,
+                CONF_TOD_RATE_BASIC_SERVICE: 0.12,
+            }
+        )
+        validated_rates = schema(with_rates)
+        assert validated_rates[CONF_TOD_RATE_OFF_PEAK] == pytest.approx(0.0893)
+        assert validated_rates[CONF_TOD_RATE_ON_PEAK] == pytest.approx(0.4313)
+
+    @pytest.mark.asyncio
+    async def test_options_settings_saves_with_blank_tod_rates(self):
+        flow = PGEOptionsFlow()
+        entry = MagicMock()
+        entry.entry_id = "entry1"
+        entry.options = {}
+        entry.data = {}
+        flow.hass = MagicMock()
+        flow.handler = "entry1"
+        flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=entry)
+
+        result = await flow.async_step_settings(
+            {
+                CONF_POLLING_INTERVAL: 4,
+                CONF_POLLING_INTERVAL_UNIT: PollingIntervalUnit.HOURS.value,
+                CONF_SYNC_LOCAL_TIME: DEFAULT_SYNC_LOCAL_TIME,
+                CONF_CORRECTION_WINDOW: 7,
+                CONF_HISTORY_MODE: HistoryMode.FULL.value,
+                CONF_HISTORY_START_DATE: "2019-01-01",
+                CONF_HOURLY_BACKFILL_DAYS: 90,
+                CONF_AUTO_BACKFILL: True,
+                CONF_INCLUDE_COST: True,
+                CONF_INCLUDE_DIAGNOSTICS: True,
+                CONF_CAPTURE_GRAPHQL_DIAGNOSTICS: True,
+                CONF_INCLUDE_BILLING: True,
+                CONF_DOWNLOAD_BILL_PDFS: False,
+                CONF_BILL_PDF_FORM: "detailed",
+                CONF_BILL_PDF_RETENTION: "latest",
+                CONF_BILL_PDF_ROLLING_COUNT: 12,
+                CONF_BACKFILL_CONCURRENCY: 2,
+                CONF_TOD_RATE_OFF_PEAK: None,
+                CONF_TOD_RATE_MID_PEAK: "",
+                CONF_TOD_RATE_ON_PEAK: None,
+                CONF_TOD_RATE_BASIC_SERVICE: "",
+            }
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_CAPTURE_GRAPHQL_DIAGNOSTICS] is True
+        assert result["data"][CONF_TOD_RATE_OFF_PEAK] is None
+        assert result["data"][CONF_TOD_RATE_MID_PEAK] is None
+        assert result["data"][CONF_TOD_RATE_ON_PEAK] is None
+        assert result["data"][CONF_TOD_RATE_BASIC_SERVICE] is None
 
     @pytest.mark.asyncio
     async def test_options_init_shows_menu(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sync settings Submit failed with four identical **expected float** errors whenever the optional TOD rate override boxes were left blank (the default). That also blocked enabling **diagnostic capture**.

Root cause: bare `NumberSelector` rejects `None`/`""`, and `vol.Optional(..., default=None)` inserts `None` for omitted keys, so the four TOD rate fields always failed validation on Submit.

## Fix

- Add `OptionalNumberSelector` (subclass of HA `NumberSelector`) that treats blank/`None` as unset
- Keep number-box UI serialization (`step: any` for fractional USD/kWh)
- Existing `_clean_tod_rate` still stores `None` for blank overrides
- PATCH **v0.9.10** (`const.py` / `manifest.json` / frontend `?v=` / README)

## Test plan

- [x] Unit: blank/`None`/`""` TOD rates validate; fractional overrides still coerce
- [x] Unit: Sync settings step saves with blank TOD rates + diagnostic capture on
- [x] Full `scripts/run_tests.sh`
- [ ] After merge/release: on HA, Configure → Sync settings → Submit with no TOD overrides; enable diagnostic capture and confirm it saves

Fixes the Sync settings regression reported on https://github.com/spencerthayer/homeassistant-pge/issues/5#issuecomment-5300493382

ASSUMPTIONS: No HACS GitHub Release until explicit approval after green CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a005de-a81f-7273-ba12-fd8a0045fe0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a005de-a81f-7273-ba12-fd8a0045fe0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

