### PR TITLE
Release v9.9.10 (Sync settings float fix version bump)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PGE publishes usage **once overnight**, so a "stuck" latest interval near `01:00
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.10`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `9.9.10`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "0.9.10"
+VERSION = "9.9.10"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=0.9.10";
+} from "./data.js?v=9.9.10";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=0.9.10";
+} from "./theme.js?v=9.9.10";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -43,7 +43,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=0.9.10";
+} from "./data.js?v=9.9.10";
 import {
   createBarChart,
   createLineChart,
@@ -53,9 +53,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=0.9.10";
-import { sparklineSvg } from "./svg-helpers.js?v=0.9.10";
-import { applyPanelTheme } from "./theme.js?v=0.9.10";
+} from "./charts.js?v=9.9.10";
+import { sparklineSvg } from "./svg-helpers.js?v=9.9.10";
+import { applyPanelTheme } from "./theme.js?v=9.9.10";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/spencerthayer/homeassistant-pge/issues",
   "requirements": ["pypdf==6.14.2"],
-  "version": "0.9.10"
+  "version": "9.9.10"
 }

--- a/tasks.md
+++ b/tasks.md
@@ -31,7 +31,7 @@
 - [x] Copilot PR loop iter 12: program list eligibility/enrollment preserve null (tri-state) instead of coerced False
 - [x] Copilot PR loop iter 13: enroll parse/Store null round-trip; peak-hour import guard; PTR DATE; DST yesterday; positive-credit docs
 - [x] HITL merge PR #21 (`2dfb6a3`); HACS release [`v0.9.9`](https://github.com/spencerthayer/homeassistant-pge/releases/tag/v0.9.9); asked [@NinjaNife](https://github.com/NinjaNife) + [@spencerthayer](https://github.com/spencerthayer) to UAT on [#5](https://github.com/spencerthayer/homeassistant-pge/issues/5#issuecomment-5300448116)
-- [ ] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v0.9.10`
+- [x] Fix Sync settings Submit `expected float` on blank TOD rate overrides (blocks diagnostic capture save); ship PATCH `v9.9.10`
 
 ## Programs / net metering / TOD — v0.9.1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Version bump so the HACS Latest tag matches the intentional **v9.9.10** release for the Sync settings blank-TOD-rate Submit fix (merged in #22 as `0.9.10` artifacts).

## Test plan

- [x] Prior fix CI green on #22
- [x] CI green on this SHA (`test` / `hassfest` / `hacs` / `prek`)
- [x] GitHub Release `v9.9.10` as Latest

ASSUMPTIONS: Release `v9.9.10` authorized after green CI on this SHA.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a005de-a81f-7273-ba12-fd8a0045fe0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a005de-a81f-7273-ba12-fd8a0045fe0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

