### PR TITLE
v0.9.12: Discover all ACTIVE PGE accounts on a login (issue #20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# Create a GitHub Release (HACS Latest) when VERSION lands on main
+# and no matching tag exists yet. Squash/merge of a version-bump PR
+# is what publishes; re-running after the tag exists is a no-op.
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read integration version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="$(python3 -c "import json; print(json.load(open('custom_components/pge_energy/manifest.json'))['version'])")"
+          CONST_VERSION="$(python3 -c "import pathlib,re; t=pathlib.Path('custom_components/pge_energy/const.py').read_text(); print(re.search(r'^VERSION = \"([^\"]+)\"', t, re.M).group(1))")"
+          if [[ "$VERSION" != "$CONST_VERSION" ]]; then
+            echo "manifest.json version ($VERSION) != const.py VERSION ($CONST_VERSION)" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping"
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --target "${{ github.sha }}" \
+            --title "$TAG" \
+            --notes "HACS release \`$VERSION\` from \`${{ github.sha }}\`." \
+            --latest

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PGE publishes usage **once overnight**, so a "stuck" latest interval near `01:00
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `9.10.0`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.12`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PGE publishes usage **once overnight**, so a "stuck" latest interval near `01:00
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.9.11`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `9.10.0`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/custom_components/pge_energy/billing_api.py
+++ b/custom_components/pge_energy/billing_api.py
@@ -380,8 +380,13 @@ def _normalize_account_digits(value: str) -> str:
     return digits.lstrip("0") or ("0" if digits else "")
 
 
-def _account_detail_list_params(*, limit: int = 50) -> dict[str, Any]:
-    """Shared AccountDetailList params; high limit covers multi-account logins."""
+def account_detail_list_params(*, limit: int = 50) -> dict[str, Any]:
+    """Shared AccountDetailList params; high limit covers multi-account logins.
+
+    Used by billing sync and by credential account discovery (portal_auth).
+    ``accountStatus: ACTIVE`` matches the portal account switcher for billable
+    accounts; inactive/closed numbers are intentionally omitted.
+    """
     return {
         "accountStatus": "ACTIVE",
         "groupId": "ALL_ACCTS",
@@ -389,6 +394,10 @@ def _account_detail_list_params(*, limit: int = 50) -> dict[str, Any]:
         "sort": {"direction": "ASC", "sort": "DEFAULT"},
         "filter": {"filterBy": "", "operator": "STARTSWITH"},
     }
+
+
+# Compat alias for existing callers.
+_account_detail_list_params = account_detail_list_params
 
 
 def _select_account(

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "9.10.0"
+VERSION = "0.9.12"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "0.9.11"
+VERSION = "9.10.0"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=0.9.11";
+} from "./data.js?v=9.10.0";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=0.9.11";
+} from "./theme.js?v=9.10.0";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=9.10.0";
+} from "./data.js?v=0.9.12";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=9.10.0";
+} from "./theme.js?v=0.9.12";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -44,7 +44,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=9.10.0";
+} from "./data.js?v=0.9.12";
 import {
   createBarChart,
   createLineChart,
@@ -54,9 +54,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=9.10.0";
-import { sparklineSvg } from "./svg-helpers.js?v=9.10.0";
-import { applyPanelTheme } from "./theme.js?v=9.10.0";
+} from "./charts.js?v=0.9.12";
+import { sparklineSvg } from "./svg-helpers.js?v=0.9.12";
+import { applyPanelTheme } from "./theme.js?v=0.9.12";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -44,7 +44,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=0.9.11";
+} from "./data.js?v=9.10.0";
 import {
   createBarChart,
   createLineChart,
@@ -54,9 +54,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=0.9.11";
-import { sparklineSvg } from "./svg-helpers.js?v=0.9.11";
-import { applyPanelTheme } from "./theme.js?v=0.9.11";
+} from "./charts.js?v=9.10.0";
+import { sparklineSvg } from "./svg-helpers.js?v=9.10.0";
+import { applyPanelTheme } from "./theme.js?v=9.10.0";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/spencerthayer/homeassistant-pge/issues",
   "requirements": ["pypdf==6.14.2"],
-  "version": "9.10.0"
+  "version": "0.9.12"
 }

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/spencerthayer/homeassistant-pge/issues",
   "requirements": ["pypdf==6.14.2"],
-  "version": "0.9.11"
+  "version": "9.10.0"
 }

--- a/custom_components/pge_energy/portal_auth.py
+++ b/custom_components/pge_energy/portal_auth.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode
 
 import aiohttp
 
+from .billing_api import GET_ACCOUNT_DETAIL_LIST, account_detail_list_params
 from .const import (
     COGNITO_RATE_LIMIT_DEFAULT_SECONDS,
     COGNITO_RATE_LIMIT_LOCKOUT_SECONDS,
@@ -244,7 +245,35 @@ async def _apigee_exchange_id_token(
     return token, _parse_expires_at(payload.get("expires_at"))
 
 
+def _account_number_last4(value: str) -> str:
+    """Sanitized account fingerprint for diagnostics (never log full numbers)."""
+    digits = "".join(ch for ch in str(value) if ch.isdigit())
+    if not digits:
+        return "????"
+    if len(digits) <= 4:
+        return digits
+    return digits[-4:]
+
+
+def _merge_account_ids(*groups: list[str]) -> list[str]:
+    """Union account numbers in encounter order (exact-string dedupe)."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for acct in group:
+            if not isinstance(acct, str) or not acct or acct in seen:
+                continue
+            seen.add(acct)
+            merged.append(acct)
+    return merged
+
+
 def _extract_accounts(account_info: dict[str, Any]) -> tuple[str | None, list[str]]:
+    """Collect defaultAccount numbers from getAccountInfo groups.
+
+    ``getAccountInfo`` only returns each group's defaultAccount — non-default
+    accounts on the same login are invisible here (see getAccountDetailList).
+    """
     person = account_info.get("encryptedPersonId")
     person_id = person if isinstance(person, str) and person else None
     account_ids: list[str] = []
@@ -263,6 +292,88 @@ def _extract_accounts(account_info: dict[str, Any]) -> tuple[str | None, list[st
             if person_id is None and isinstance(enc_person, str) and enc_person:
                 person_id = enc_person
     return person_id, account_ids
+
+
+def _extract_detail_list_accounts(detail_list: dict[str, Any]) -> tuple[str | None, list[str]]:
+    """Collect accountNumber values from getAccountDetailList.accounts[]."""
+    person_id: str | None = None
+    account_ids: list[str] = []
+    accounts = detail_list.get("accounts") or []
+    if not isinstance(accounts, list):
+        return person_id, account_ids
+    for row in accounts:
+        if not isinstance(row, dict):
+            continue
+        acct = row.get("accountNumber")
+        if isinstance(acct, str) and acct and acct not in account_ids:
+            account_ids.append(acct)
+        enc_person = row.get("encryptedPersonId")
+        if person_id is None and isinstance(enc_person, str) and enc_person:
+            person_id = enc_person
+    return person_id, account_ids
+
+
+def _log_discovery_summary(
+    *,
+    account_meta: dict[str, Any] | None,
+    groups: list[Any] | None,
+    default_ids: list[str],
+    detail_ids: list[str] | None,
+    merged_ids: list[str],
+    detail_error: str | None,
+) -> None:
+    """Bounded sanitized discovery diagnostics (last-4 only; no ciphertexts)."""
+    meta = account_meta if isinstance(account_meta, dict) else {}
+    group_rows = groups if isinstance(groups, list) else []
+    group_summaries: list[str] = []
+    for group in group_rows:
+        if not isinstance(group, dict):
+            continue
+        n_declared = group.get("numberOfAccounts")
+        default = group.get("defaultAccount") if isinstance(group.get("defaultAccount"), dict) else {}
+        default_acct = default.get("accountNumber") if isinstance(default, dict) else None
+        last4 = _account_number_last4(default_acct) if isinstance(default_acct, str) else "none"
+        group_summaries.append(f"declared={n_declared!r}/default_last4={last4}")
+    if detail_ids is not None:
+        detail_last4 = [_account_number_last4(a) for a in detail_ids]
+        detail_part = f"detail_count={len(detail_ids)} last4={detail_last4}"
+    else:
+        detail_part = f"detail_soft_fail={detail_error or 'unknown'}"
+    _LOGGER.debug(
+        "PGE account discovery: totalAccounts=%r hasInactive=%r groups=%s "
+        "defaults=%s %s merged=%s last4=%s",
+        meta.get("totalAccounts"),
+        meta.get("hasInactiveAccounts"),
+        group_summaries or "[]",
+        len(default_ids),
+        detail_part,
+        len(merged_ids),
+        [_account_number_last4(a) for a in merged_ids],
+    )
+
+
+async def _enumerate_accounts_via_detail_list(
+    session: aiohttp.ClientSession,
+    access_token: str,
+    *,
+    headers: dict[str, str],
+) -> tuple[str | None, list[str]]:
+    """Enumerate ACTIVE accounts via the portal account-switcher op."""
+    body = {
+        "operationName": "getAccountDetailList",
+        "query": GET_ACCOUNT_DETAIL_LIST,
+        "variables": {"params": account_detail_list_params()},
+    }
+    status, payload = await _post_json(session, GRAPHQL_URL, headers=headers, body=body)
+    classify_challenge(payload)
+    if status >= 400:
+        raise PGEAuthenticationError(f"PGE account detail list failed (HTTP {status})")
+    if payload.get("errors"):
+        raise PGEAuthenticationError("PGE account detail list GraphQL errors")
+    detail = (payload.get("data") or {}).get("getAccountDetailList")
+    if not isinstance(detail, dict):
+        raise PGEAuthenticationError("PGE account detail list returned no getAccountDetailList")
+    return _extract_detail_list_accounts(detail)
 
 
 async def _discover_accounts(
@@ -291,7 +402,33 @@ async def _discover_accounts(
     info = (payload.get("data") or {}).get("getAccountInfo")
     if not isinstance(info, dict):
         raise PGEAuthenticationError("PGE account discovery returned no getAccountInfo")
-    return _extract_accounts(info)
+    person_id, default_ids = _extract_accounts(info)
+
+    detail_ids: list[str] | None = None
+    detail_error: str | None = None
+    try:
+        detail_person, detail_ids = await _enumerate_accounts_via_detail_list(
+            session, access_token, headers=headers
+        )
+        if person_id is None and detail_person:
+            person_id = detail_person
+    except Exception as exc:  # noqa: BLE001 - soft-fail; never regress single-account login
+        detail_error = type(exc).__name__
+        _LOGGER.debug(
+            "PGE getAccountDetailList enumeration soft-failed; using getAccountInfo defaults only",
+            exc_info=True,
+        )
+
+    merged = _merge_account_ids(default_ids, detail_ids or [])
+    _log_discovery_summary(
+        account_meta=info.get("accountMeta") if isinstance(info.get("accountMeta"), dict) else None,
+        groups=info.get("groups") if isinstance(info.get("groups"), list) else None,
+        default_ids=default_ids,
+        detail_ids=detail_ids,
+        merged_ids=merged,
+        detail_error=detail_error,
+    )
+    return person_id, merged
 
 
 async def _login_with_password(

--- a/custom_components/pge_energy/portal_auth.py
+++ b/custom_components/pge_energy/portal_auth.py
@@ -342,6 +342,8 @@ def _log_discovery_summary(
     detail_error: str | None,
 ) -> None:
     """Bounded sanitized discovery diagnostics (last-4 only; no ciphertexts)."""
+    if not _LOGGER.isEnabledFor(logging.DEBUG):
+        return
     meta = account_meta if isinstance(account_meta, dict) else {}
     group_rows = groups if isinstance(groups, list) else []
     group_summaries: list[str] = []

--- a/custom_components/pge_energy/portal_auth.py
+++ b/custom_components/pge_energy/portal_auth.py
@@ -15,7 +15,7 @@ from urllib.parse import urlencode
 
 import aiohttp
 
-from .billing_api import GET_ACCOUNT_DETAIL_LIST, account_detail_list_params
+from .billing_api import account_detail_list_params
 from .const import (
     COGNITO_RATE_LIMIT_DEFAULT_SECONDS,
     COGNITO_RATE_LIMIT_LOCKOUT_SECONDS,
@@ -76,6 +76,16 @@ query getAccountInfo($params: GetAccountInfoParams) {
       }
     }
   }
+}
+"""
+
+# Minimal getAccountDetailList for account discovery. The full billing document
+# (billInfo/autoPay/premise/temperature) is overfetch on the auth path and would
+# pull billing data on every login/renewal. Keep the field selection one-line:
+# multiline selections have been observed to trip Apigee/WAF 403s.
+_GET_ACCOUNT_DETAIL_LIST_MINIMAL = """
+query getAccountDetailList($params: AccountDetailListParams!) {
+  getAccountDetailList(params: $params) { totalCount accounts { accountNumber encryptedPersonId } }
 }
 """
 
@@ -313,6 +323,15 @@ def _extract_detail_list_accounts(detail_list: dict[str, Any]) -> tuple[str | No
     return person_id, account_ids
 
 
+def _total_accounts_from_meta(account_meta: dict[str, Any] | None) -> int | None:
+    """accountMeta.totalAccounts as int; None when absent or non-numeric."""
+    value = account_meta.get("totalAccounts") if isinstance(account_meta, dict) else None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _log_discovery_summary(
     *,
     account_meta: dict[str, Any] | None,
@@ -337,8 +356,10 @@ def _log_discovery_summary(
     if detail_ids is not None:
         detail_last4 = [_account_number_last4(a) for a in detail_ids]
         detail_part = f"detail_count={len(detail_ids)} last4={detail_last4}"
+    elif detail_error is None:
+        detail_part = "detail_skipped=totalAccounts_covered_by_defaults"
     else:
-        detail_part = f"detail_soft_fail={detail_error or 'unknown'}"
+        detail_part = f"detail_soft_fail={detail_error}"
     _LOGGER.debug(
         "PGE account discovery: totalAccounts=%r hasInactive=%r groups=%s defaults=%s %s merged=%s last4=%s",
         meta.get("totalAccounts"),
@@ -360,10 +381,11 @@ async def _enumerate_accounts_via_detail_list(
     """Enumerate ACTIVE accounts via the portal account-switcher op."""
     body = {
         "operationName": "getAccountDetailList",
-        "query": GET_ACCOUNT_DETAIL_LIST,
+        "query": _GET_ACCOUNT_DETAIL_LIST_MINIMAL,
         "variables": {"params": account_detail_list_params()},
     }
-    status, payload = await _post_json(session, GRAPHQL_URL, headers=headers, body=body)
+    request_headers = {**headers, "Authorization": f"Bearer {access_token}"}
+    status, payload = await _post_json(session, GRAPHQL_URL, headers=request_headers, body=body)
     classify_challenge(payload)
     if status >= 400:
         raise PGEAuthenticationError(f"PGE account detail list failed (HTTP {status})")
@@ -402,23 +424,33 @@ async def _discover_accounts(
     if not isinstance(info, dict):
         raise PGEAuthenticationError("PGE account discovery returned no getAccountInfo")
     person_id, default_ids = _extract_accounts(info)
+    account_meta = info.get("accountMeta") if isinstance(info.get("accountMeta"), dict) else None
+    total_accounts = _total_accounts_from_meta(account_meta)
 
     detail_ids: list[str] | None = None
     detail_error: str | None = None
-    try:
-        detail_person, detail_ids = await _enumerate_accounts_via_detail_list(session, access_token, headers=headers)
-        if person_id is None and detail_person:
-            person_id = detail_person
-    except Exception as exc:  # noqa: BLE001 - soft-fail; never regress single-account login
-        detail_error = type(exc).__name__
-        _LOGGER.debug(
-            "PGE getAccountDetailList enumeration soft-failed; using getAccountInfo defaults only",
-            exc_info=True,
-        )
+    # Gate on accountMeta.totalAccounts: when the portal reports that the group defaults already
+    # cover every account, skip the extra round-trip (common single-account case; tokens renew
+    # often). Unknown totalAccounts stays conservative and still enumerates.
+    if total_accounts is None or total_accounts > len(default_ids):
+        try:
+            detail_person, detail_ids = await _enumerate_accounts_via_detail_list(
+                session, access_token, headers=headers
+            )
+            if person_id is None and detail_person:
+                person_id = detail_person
+        except (PGEMfaUnsupportedError, PGECaptchaUnsupportedError):
+            raise  # MFA/CAPTCHA stay fail-closed; never soft-fail a challenge
+        except Exception as exc:  # noqa: BLE001 - soft-fail; never regress single-account login
+            detail_error = type(exc).__name__
+            _LOGGER.debug(
+                "PGE getAccountDetailList enumeration soft-failed; using getAccountInfo defaults only",
+                exc_info=True,
+            )
 
     merged = _merge_account_ids(default_ids, detail_ids or [])
     _log_discovery_summary(
-        account_meta=info.get("accountMeta") if isinstance(info.get("accountMeta"), dict) else None,
+        account_meta=account_meta,
         groups=info.get("groups") if isinstance(info.get("groups"), list) else None,
         default_ids=default_ids,
         detail_ids=detail_ids,

--- a/custom_components/pge_energy/portal_auth.py
+++ b/custom_components/pge_energy/portal_auth.py
@@ -340,8 +340,7 @@ def _log_discovery_summary(
     else:
         detail_part = f"detail_soft_fail={detail_error or 'unknown'}"
     _LOGGER.debug(
-        "PGE account discovery: totalAccounts=%r hasInactive=%r groups=%s "
-        "defaults=%s %s merged=%s last4=%s",
+        "PGE account discovery: totalAccounts=%r hasInactive=%r groups=%s defaults=%s %s merged=%s last4=%s",
         meta.get("totalAccounts"),
         meta.get("hasInactiveAccounts"),
         group_summaries or "[]",
@@ -407,9 +406,7 @@ async def _discover_accounts(
     detail_ids: list[str] | None = None
     detail_error: str | None = None
     try:
-        detail_person, detail_ids = await _enumerate_accounts_via_detail_list(
-            session, access_token, headers=headers
-        )
+        detail_person, detail_ids = await _enumerate_accounts_via_detail_list(session, access_token, headers=headers)
         if person_id is None and detail_person:
             person_id = detail_person
     except Exception as exc:  # noqa: BLE001 - soft-fail; never regress single-account login

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ flowchart TD
 ### Authentication (production)
 
 1. Setup collects **email + password + account number** (required). Same login may create multiple entries with different account numbers; separate logins each get their own entry.
-2. `portal_auth` login (Cognito `USER_PASSWORD_AUTH` → Apigee bearer → `getAccountInfo`); match the entered account number to discovered accounts (exact or digits-only).
+2. `portal_auth` login (Cognito `USER_PASSWORD_AUTH` → Apigee bearer → `getAccountInfo` defaults merged with `getAccountDetailList` ACTIVE accounts); match the entered account number to discovered accounts (exact or digits-only).
 3. Validate with HOURLY yesterday `GetUsageCompare`; persist email, renewal secret (or password fallback), account id, person id, and a stable `account_key` derived from the account number. Best-effort AccountDetail discovery also persists encrypted account / premise / SA ids for programs and ledger. Entry unique id is account-scoped (`pge_account_<id>`). Title/device name: `PGE <accountnum>` (entity ids use the account number; Energy statistic ids use `account_key`).
 4. Keep access token in memory; renew under async lock before GraphQL calls (skew before expiry; forced 401 renew+retry on credential mode). Tokens are short-lived — password/refresh re-login may run nearly every sync.
 5. Cognito `TooManyRequests` / “Password attempts exceeded” → `PGERateLimitError` with a shared per-email cooldown (no further InitiateAuth while cooling down; no password→refresh amplify; soft-fail retains sensors without reauth UI). Concurrent `force_renew` waiters coalesce onto one login. See [`AUTH_DISCOVERY.md`](AUTH_DISCOVERY.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ flowchart TD
 ### Authentication (production)
 
 1. Setup collects **email + password + account number** (required). Same login may create multiple entries with different account numbers; separate logins each get their own entry.
-2. `portal_auth` login (Cognito `USER_PASSWORD_AUTH` → Apigee bearer → `getAccountInfo` defaults merged with `getAccountDetailList` ACTIVE accounts); match the entered account number to discovered accounts (exact or digits-only).
+2. `portal_auth` login (Cognito `USER_PASSWORD_AUTH` → Apigee bearer → `getAccountInfo` defaults merged with `getAccountDetailList` ACTIVE accounts, gated on `accountMeta.totalAccounts`); match the entered account number to discovered accounts (exact or digits-only).
 3. Validate with HOURLY yesterday `GetUsageCompare`; persist email, renewal secret (or password fallback), account id, person id, and a stable `account_key` derived from the account number. Best-effort AccountDetail discovery also persists encrypted account / premise / SA ids for programs and ledger. Entry unique id is account-scoped (`pge_account_<id>`). Title/device name: `PGE <accountnum>` (entity ids use the account number; Energy statistic ids use `account_key`).
 4. Keep access token in memory; renew under async lock before GraphQL calls (skew before expiry; forced 401 renew+retry on credential mode). Tokens are short-lived — password/refresh re-login may run nearly every sync.
 5. Cognito `TooManyRequests` / “Password attempts exceeded” → `PGERateLimitError` with a shared per-email cooldown (no further InitiateAuth while cooling down; no password→refresh amplify; soft-fail retains sensors without reauth UI). Concurrent `force_renew` waiters coalesce onto one login. See [`AUTH_DISCOVERY.md`](AUTH_DISCOVERY.md).

--- a/docs/AUTH_DISCOVERY.md
+++ b/docs/AUTH_DISCOVERY.md
@@ -8,8 +8,8 @@ Protocol notes for the unofficial Portland General Electric portal login chain u
 2. Exchange Cognito `IdToken` at Apigee `pg-token-implicit-aws/token` → short-lived bearer + `expires_at`.
 3. GraphQL account discovery with the Apigee bearer:
    - `getAccountInfo` → encrypted person id + each group's `defaultAccount` number.
-   - `getAccountDetailList` (`groupId: ALL_ACCTS`, `accountStatus: ACTIVE`) → full ACTIVE account list for the login.
-   - Merge (union, defaults first) so non-default accounts on a shared login are selectable in config flow. Soft-fail the detail-list call and keep `getAccountInfo` defaults if enumeration fails.
+   - `getAccountDetailList` (`groupId: ALL_ACCTS`, `accountStatus: ACTIVE`) → full ACTIVE account list for the login, via a minimal document (`totalCount`, `accounts { accountNumber encryptedPersonId }`). Gated on `accountMeta.totalAccounts`: skipped when the group defaults already cover every account (single-account logins avoid the extra round-trip); unknown `totalAccounts` still enumerates.
+   - Merge (union, defaults first) so non-default accounts on a shared login are selectable in config flow. Soft-fail transient detail-list errors and keep `getAccountInfo` defaults; MFA/CAPTCHA challenges on the detail-list call fail closed.
 4. Runtime renewal prefers password re-login when stored; falls back to `REFRESH_TOKEN_AUTH` only on recoverable credential auth errors (not throttle).
 
 MFA / CAPTCHA challenges fail closed (`PGEMfaUnsupportedError` / `PGECaptchaUnsupportedError`).

--- a/docs/AUTH_DISCOVERY.md
+++ b/docs/AUTH_DISCOVERY.md
@@ -6,10 +6,15 @@ Protocol notes for the unofficial Portland General Electric portal login chain u
 
 1. Cognito `InitiateAuth` with `USER_PASSWORD_AUTH` (public client id from portal bundle).
 2. Exchange Cognito `IdToken` at Apigee `pg-token-implicit-aws/token` → short-lived bearer + `expires_at`.
-3. GraphQL `getAccountInfo` with the Apigee bearer → encrypted person id + account list.
+3. GraphQL account discovery with the Apigee bearer:
+   - `getAccountInfo` → encrypted person id + each group's `defaultAccount` number.
+   - `getAccountDetailList` (`groupId: ALL_ACCTS`, `accountStatus: ACTIVE`) → full ACTIVE account list for the login.
+   - Merge (union, defaults first) so non-default accounts on a shared login are selectable in config flow. Soft-fail the detail-list call and keep `getAccountInfo` defaults if enumeration fails.
 4. Runtime renewal prefers password re-login when stored; falls back to `REFRESH_TOKEN_AUTH` only on recoverable credential auth errors (not throttle).
 
 MFA / CAPTCHA challenges fail closed (`PGEMfaUnsupportedError` / `PGECaptchaUnsupportedError`).
+
+Sanitized DEBUG diagnostics log discovery counts and account-number last-4 digits only (never full numbers, encrypted ids, or tokens).
 
 ## Cognito rate limits (live probe 2026-07-29)
 

--- a/docs/DATA_CONTRACT.md
+++ b/docs/DATA_CONTRACT.md
@@ -215,12 +215,24 @@ The default-off `capture_graphql_diagnostics` switch remains available for follo
 
 Same Apigee endpoint (`https://apix.portlandgeneral.com/pge-graphql`) and bearer as usage. Prefer portal Origin/Referer (`https://portlandgeneral.com`). Implemented in `billing_api.py`.
 
+### Account discovery (credential setup / renew)
+
+Credential login discovers which account numbers belong to the login **before** usage validation:
+
+1. `getAccountInfo` — returns `accountMeta` plus each group's `defaultAccount.accountNumber` only (non-default accounts are not selected by the document).
+2. `getAccountDetailList` with `groupId: "ALL_ACCTS"` and `accountStatus: "ACTIVE"` — portal account-switcher source; returns every ACTIVE `accounts[].accountNumber` (paging limit 50).
+3. Merge: union of defaults + detail-list rows (exact-string dedupe, defaults first). Soft-fail detail-list errors and keep defaults so single-account flows never regress.
+4. Config flow still requires the user-entered number to match a discovered id (exact or digits-only). Empty discovery still accepts the typed value for usage validation.
+
+**Caveat:** discovery keeps `accountStatus: "ACTIVE"`. Inactive/closed accounts that remain browsable on the portal may still fail with `account_not_found` until a separate status strategy is justified.
+
 ### `getAccountDetailList` (`AccountDetailListParams!`)
 
-- **Purpose:** account summary, latest bill details, Auto Pay / paperless flags, encrypted account / person / premise / SA ids.
+- **Purpose:** account summary, latest bill details, Auto Pay / paperless flags, encrypted account / person / premise / SA ids; also used to **enumerate ACTIVE accounts** during credential discovery (`portal_auth`).
 - **Typical variables:** `{ accountStatus: "ACTIVE", groupId: "ALL_ACCTS", paging, sort, filter }`.
 - **Key fields:** `billInfo.{amountDue,dueDate,lastPaymentAmount,lastPaymentDate,billDetails…}`, `autoPay.isEnrolled`, `isPaperlessBillEnrolled.result`, `premiseInfo[].encryptedPremiseId`, `saDetails[].encryptedSAId`, `viewBillAverageTemperature.currentBillingPeriod.averageTemperature`.
 - **Identity note:** AccountDetail `encryptedAccountNumber` can differ from `getAccountInfo` group defaults — prefer AccountDetail for programs/history.
+- **Multi-account:** logins with multiple ACTIVE accounts return multiple `accounts[]` rows (issue #20).
 
 ### Nested `AccountDetail.paymentHistory` (`PaymentHistoryParams`)
 

--- a/docs/DATA_CONTRACT.md
+++ b/docs/DATA_CONTRACT.md
@@ -220,8 +220,8 @@ Same Apigee endpoint (`https://apix.portlandgeneral.com/pge-graphql`) and bearer
 Credential login discovers which account numbers belong to the login **before** usage validation:
 
 1. `getAccountInfo` — returns `accountMeta` plus each group's `defaultAccount.accountNumber` only (non-default accounts are not selected by the document).
-2. `getAccountDetailList` with `groupId: "ALL_ACCTS"` and `accountStatus: "ACTIVE"` — portal account-switcher source; returns every ACTIVE `accounts[].accountNumber` (paging limit 50).
-3. Merge: union of defaults + detail-list rows (exact-string dedupe, defaults first). Soft-fail detail-list errors and keep defaults so single-account flows never regress.
+2. `getAccountDetailList` with `groupId: "ALL_ACCTS"` and `accountStatus: "ACTIVE"` — portal account-switcher source; returns every ACTIVE `accounts[].accountNumber` (paging limit 50). **Gated:** skipped when `accountMeta.totalAccounts` is known and ≤ the number of discovered group defaults (common single-account case — avoids an extra round-trip on every login/renewal); unknown `totalAccounts` still enumerates. Discovery uses a **minimal** document (`totalCount`, `accounts { accountNumber encryptedPersonId }`) — the full billing document stays with billing sync.
+3. Merge: union of defaults + detail-list rows (exact-string dedupe, defaults first). Soft-fail transient detail-list errors and keep defaults so single-account flows never regress; MFA/CAPTCHA challenges on the detail-list call fail closed (`PGEMfaUnsupportedError` / `PGECaptchaUnsupportedError`).
 4. Config flow still requires the user-entered number to match a discovered id (exact or digits-only). Empty discovery still accepts the typed value for usage validation.
 
 **Caveat:** discovery keeps `accountStatus: "ACTIVE"`. Inactive/closed accounts that remain browsable on the portal may still fail with `account_not_found` until a separate status strategy is justified.

--- a/tasks.md
+++ b/tasks.md
@@ -7,9 +7,9 @@
 - [x] Sanitized DEBUG discovery diagnostics (counts + last-4 only)
 - [x] Fixtures/tests: two-accounts-one-default, detail-list soft-fail, multi-group, digits-only second account, unknown still rejected
 - [x] Copilot review hardening (PR #25): gate detail-list on `accountMeta.totalAccounts`, fail-closed MFA/CAPTCHA on the detail-list call, minimal discovery GraphQL document (no billing overfetch)
-- [x] Docs: `AUTH_DISCOVERY.md`, `DATA_CONTRACT.md`; VERSION `9.10.0`
+- [x] Docs: `AUTH_DISCOVERY.md`, `DATA_CONTRACT.md`; VERSION `0.9.12`
 - [ ] Green CI on PR; live HA single-account UAT; reporter multi-account UAT
-- [ ] HITL merge + HITL HACS release `v9.10.0` (do not publish without approval)
+- [ ] HITL squash/merge PR #25 → `Release` workflow publishes `v0.9.12` Latest when the tag is missing
 - [ ] Comment on [#20](https://github.com/spencerthayer/homeassistant-pge/issues/20) after release
 
 ## Grid import/export — issue #5

--- a/tasks.md
+++ b/tasks.md
@@ -1,5 +1,16 @@
 # Tasks
 
+## Multi-account discovery — issue #20
+
+- [x] Root cause: `getAccountInfo` only surfaces each group's `defaultAccount`; non-default accounts never enter config-flow matching (`account_not_found`)
+- [x] Broaden discovery: merge `getAccountDetailList(ALL_ACCTS, ACTIVE)` account numbers with `getAccountInfo` defaults (soft-fail detail list)
+- [x] Sanitized DEBUG discovery diagnostics (counts + last-4 only)
+- [x] Fixtures/tests: two-accounts-one-default, detail-list soft-fail, multi-group, digits-only second account, unknown still rejected
+- [x] Docs: `AUTH_DISCOVERY.md`, `DATA_CONTRACT.md`; VERSION `9.10.0`
+- [ ] Green CI on PR; live HA single-account UAT; reporter multi-account UAT
+- [ ] HITL merge + HITL HACS release `v9.10.0` (do not publish without approval)
+- [ ] Comment on [#20](https://github.com/spencerthayer/homeassistant-pge/issues/20) after release
+
 ## Grid import/export — issue #5
 
 - [x] Ship default-off GraphQL diagnostic capture and collect NinjaNife's generating-account logs

--- a/tasks.md
+++ b/tasks.md
@@ -6,6 +6,7 @@
 - [x] Broaden discovery: merge `getAccountDetailList(ALL_ACCTS, ACTIVE)` account numbers with `getAccountInfo` defaults (soft-fail detail list)
 - [x] Sanitized DEBUG discovery diagnostics (counts + last-4 only)
 - [x] Fixtures/tests: two-accounts-one-default, detail-list soft-fail, multi-group, digits-only second account, unknown still rejected
+- [x] Copilot review hardening (PR #25): gate detail-list on `accountMeta.totalAccounts`, fail-closed MFA/CAPTCHA on the detail-list call, minimal discovery GraphQL document (no billing overfetch)
 - [x] Docs: `AUTH_DISCOVERY.md`, `DATA_CONTRACT.md`; VERSION `9.10.0`
 - [ ] Green CI on PR; live HA single-account UAT; reporter multi-account UAT
 - [ ] HITL merge + HITL HACS release `v9.10.0` (do not publish without approval)

--- a/tests/components/pge_energy/test_config_flow.py
+++ b/tests/components/pge_energy/test_config_flow.py
@@ -189,6 +189,40 @@ class TestPGEConfigFlow:
         assert result["type"] == "form"
         assert result["errors"]["base"] == "account_not_found"
 
+    @pytest.mark.asyncio
+    async def test_credential_setup_accepts_non_default_discovered_account(self):
+        """Issue #20: non-default account on the login resolves when discovery merged it."""
+        flow = PGEConfigFlow()
+        flow.hass = MagicMock()
+        login = PortalAuthResult(
+            access_token="tok",
+            encrypted_person_id="enc",
+            account_ids=["1122334455", "9988776655"],
+            expires_at=None,
+            refresh_credential="refresh",
+        )
+        with (
+            patch(
+                "custom_components.pge_energy.config_flow.portal_auth.async_login_or_refresh",
+                AsyncMock(return_value=login),
+            ),
+            patch.object(
+                flow,
+                "_async_finish_credential_entry",
+                AsyncMock(return_value={"type": "create_entry"}),
+            ) as finish,
+        ):
+            result = await flow.async_step_credential(
+                {
+                    CONF_EMAIL: "user@example.com",
+                    CONF_PASSWORD: "secret",
+                    CONF_ACCOUNT_ID: "9988-776-655",
+                }
+            )
+        assert result["type"] == "create_entry"
+        assert flow._account_id == "9988776655"
+        finish.assert_awaited_once()
+
     def test_create_credential_entry(self):
         flow = PGEConfigFlow()
         flow._token = "test_token"

--- a/tests/components/pge_energy/test_portal_auth.py
+++ b/tests/components/pge_energy/test_portal_auth.py
@@ -532,4 +532,3 @@ class TestAccountDiscoveryMerge:
                 refresh_credential=None,
             )
         assert result.account_ids == ["1111111111", "2222222222", "3333333333"]
-

--- a/tests/components/pge_energy/test_portal_auth.py
+++ b/tests/components/pge_energy/test_portal_auth.py
@@ -13,6 +13,9 @@ from custom_components.pge_energy.exceptions import (
 )
 from custom_components.pge_energy.portal_auth import (
     _classify_cognito_error,
+    _extract_accounts,
+    _extract_detail_list_accounts,
+    _merge_account_ids,
     async_login_or_refresh,
     classify_challenge,
 )
@@ -312,3 +315,221 @@ class TestLoginOrRefresh:
             )
         assert result.access_token == "apigee-from-password"
         assert result.refresh_credential == "refresh-from-password"
+
+
+class TestAccountDiscoveryMerge:
+    def test_merge_preserves_order_and_dedupes(self):
+        assert _merge_account_ids(["111"], ["111", "222"], ["333", "222"]) == ["111", "222", "333"]
+
+    def test_extract_defaults_ignores_non_default_shape(self):
+        person, ids = _extract_accounts(
+            {
+                "encryptedPersonId": "enc-person",
+                "accountMeta": {"totalAccounts": 2, "hasInactiveAccounts": False},
+                "groups": [
+                    {
+                        "numberOfAccounts": 2,
+                        "defaultAccount": {"accountNumber": "1122334455"},
+                    }
+                ],
+            }
+        )
+        assert person == "enc-person"
+        assert ids == ["1122334455"]
+
+    def test_extract_detail_list_collects_all_rows(self):
+        person, ids = _extract_detail_list_accounts(
+            {
+                "totalCount": 2,
+                "accounts": [
+                    {"accountNumber": "1122334455", "encryptedPersonId": "enc-a"},
+                    {"accountNumber": "9988776655", "encryptedPersonId": "enc-b"},
+                ],
+            }
+        )
+        assert person == "enc-a"
+        assert ids == ["1122334455", "9988776655"]
+
+    @pytest.mark.asyncio
+    async def test_login_merges_non_default_detail_list_account(self):
+        """Issue #20: second ACTIVE account is only on getAccountDetailList."""
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "accountMeta": {"totalAccounts": 2, "hasInactiveAccounts": False},
+                                "groups": [
+                                    {
+                                        "groupId": "g1",
+                                        "numberOfAccounts": 2,
+                                        "isDefault": True,
+                                        "defaultAccount": {
+                                            "accountNumber": "1122334455",
+                                            "encryptedPersonId": "enc-person",
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                ),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountDetailList": {
+                                "totalCount": 2,
+                                "accounts": [
+                                    {"accountNumber": "1122334455", "encryptedPersonId": "enc-person"},
+                                    {"accountNumber": "9988776655", "encryptedPersonId": "enc-person"},
+                                ],
+                            }
+                        }
+                    },
+                ),
+            ]
+        )
+        with patch(
+            "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+        assert result.account_ids == ["1122334455", "9988776655"]
+        assert session.post.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_login_soft_fails_detail_list_keeps_defaults(self):
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "groups": [
+                                    {
+                                        "defaultAccount": {
+                                            "accountNumber": "1122334455",
+                                            "encryptedPersonId": "enc-person",
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                ),
+                (500, {"errors": [{"message": "boom"}]}),
+            ]
+        )
+        with patch(
+            "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+        assert result.account_ids == ["1122334455"]
+
+    @pytest.mark.asyncio
+    async def test_login_multi_group_defaults_plus_detail_list(self):
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "accountMeta": {"totalAccounts": 3, "hasInactiveAccounts": False},
+                                "groups": [
+                                    {
+                                        "numberOfAccounts": 1,
+                                        "defaultAccount": {"accountNumber": "1111111111"},
+                                    },
+                                    {
+                                        "numberOfAccounts": 2,
+                                        "defaultAccount": {"accountNumber": "2222222222"},
+                                    },
+                                ],
+                            }
+                        }
+                    },
+                ),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountDetailList": {
+                                "totalCount": 3,
+                                "accounts": [
+                                    {"accountNumber": "1111111111"},
+                                    {"accountNumber": "2222222222"},
+                                    {"accountNumber": "3333333333"},
+                                ],
+                            }
+                        }
+                    },
+                ),
+            ]
+        )
+        with patch(
+            "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+        assert result.account_ids == ["1111111111", "2222222222", "3333333333"]
+

--- a/tests/components/pge_energy/test_portal_auth.py
+++ b/tests/components/pge_energy/test_portal_auth.py
@@ -16,6 +16,7 @@ from custom_components.pge_energy.portal_auth import (
     _extract_accounts,
     _extract_detail_list_accounts,
     _merge_account_ids,
+    _total_accounts_from_meta,
     async_login_or_refresh,
     classify_challenge,
 )
@@ -532,3 +533,243 @@ class TestAccountDiscoveryMerge:
                 refresh_credential=None,
             )
         assert result.account_ids == ["1111111111", "2222222222", "3333333333"]
+
+    @pytest.mark.asyncio
+    async def test_login_skips_detail_list_when_total_accounts_covered(self):
+        """Single-account login (totalAccounts=1) must not make the extra detail-list call."""
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "accountMeta": {"totalAccounts": 1, "hasInactiveAccounts": False},
+                                "groups": [
+                                    {
+                                        "defaultAccount": {
+                                            "accountNumber": "1122334455",
+                                            "encryptedPersonId": "enc-person",
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                ),
+            ]
+        )
+        with patch(
+            "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+        assert result.account_ids == ["1122334455"]
+        # Cognito + Apigee token + getAccountInfo only — no detail-list round-trip.
+        assert session.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_login_detail_list_mfa_challenge_fails_closed(self):
+        """MFA challenge on the detail-list call must fail closed, not soft-fail."""
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "accountMeta": {"totalAccounts": 2, "hasInactiveAccounts": False},
+                                "groups": [
+                                    {
+                                        "defaultAccount": {
+                                            "accountNumber": "1122334455",
+                                            "encryptedPersonId": "enc-person",
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                ),
+                (200, {"ChallengeName": "SOFTWARE_TOKEN_MFA", "Session": "sess"}),
+            ]
+        )
+        with (
+            patch(
+                "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+                return_value=session,
+            ),
+            pytest.raises(PGEMfaUnsupportedError),
+        ):
+            await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_login_detail_list_captcha_challenge_fails_closed(self):
+        """CAPTCHA challenge on the detail-list call must fail closed, not soft-fail."""
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "accountMeta": {"totalAccounts": 2, "hasInactiveAccounts": False},
+                                "groups": [
+                                    {
+                                        "defaultAccount": {
+                                            "accountNumber": "1122334455",
+                                            "encryptedPersonId": "enc-person",
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                ),
+                (200, {"captchaRequired": True}),
+            ]
+        )
+        with (
+            patch(
+                "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+                return_value=session,
+            ),
+            pytest.raises(PGECaptchaUnsupportedError),
+        ):
+            await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_detail_list_request_uses_minimal_document_and_bearer(self):
+        """Discovery must send the minimal document with a fresh bearer, not the billing overfetch."""
+        session = _mock_session_post(
+            [
+                (
+                    200,
+                    {
+                        "AuthenticationResult": {
+                            "IdToken": "id.jwt.token",
+                            "AccessToken": "access.jwt.token",
+                            "RefreshToken": "refresh-token-value",
+                            "ExpiresIn": 3600,
+                            "TokenType": "Bearer",
+                        }
+                    },
+                ),
+                (200, {"access_token": "apigee-bearer", "expires_at": 1893456000}),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountInfo": {
+                                "encryptedPersonId": "enc-person",
+                                "accountMeta": {"totalAccounts": 2, "hasInactiveAccounts": False},
+                                "groups": [
+                                    {
+                                        "defaultAccount": {
+                                            "accountNumber": "1122334455",
+                                            "encryptedPersonId": "enc-person",
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                ),
+                (
+                    200,
+                    {
+                        "data": {
+                            "getAccountDetailList": {
+                                "totalCount": 2,
+                                "accounts": [
+                                    {"accountNumber": "1122334455", "encryptedPersonId": "enc-person"},
+                                    {"accountNumber": "9988776655", "encryptedPersonId": "enc-person"},
+                                ],
+                            }
+                        }
+                    },
+                ),
+            ]
+        )
+        with patch(
+            "custom_components.pge_energy.portal_auth.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await async_login_or_refresh(
+                email="user@example.com",
+                password="secret",
+                refresh_credential=None,
+            )
+        assert result.account_ids == ["1122334455", "9988776655"]
+        detail_call = session.post.call_args_list[3]
+        assert detail_call.kwargs["headers"]["Authorization"] == "Bearer apigee-bearer"
+        query = detail_call.kwargs["json"]["query"]
+        assert "totalCount" in query and "accountNumber" in query
+        assert "billInfo" not in query and "autoPay" not in query
+
+
+class TestTotalAccountsFromMeta:
+    def test_none_when_absent(self):
+        assert _total_accounts_from_meta(None) is None
+        assert _total_accounts_from_meta({}) is None
+
+    def test_int_and_string(self):
+        assert _total_accounts_from_meta({"totalAccounts": 2}) == 2
+        assert _total_accounts_from_meta({"totalAccounts": "3"}) == 3
+
+    def test_none_when_garbage(self):
+        assert _total_accounts_from_meta({"totalAccounts": "two"}) is None

--- a/tests/fixtures/auth/README.md
+++ b/tests/fixtures/auth/README.md
@@ -14,7 +14,9 @@ Sanitized PGE credential-login fixtures for `portal_auth` / CLI tests.
 | `cognito_mfa_challenge.json` | Observed MFA challenge (`SMS_MFA`) |
 | `cognito_refresh_token_auth.json` | Cognito `REFRESH_TOKEN_AUTH` renewal |
 | `apigee_token_success.json` | Apigee `pg-token-implicit-aws` exchange |
-| `graphql_get_account_info.json` | Account discovery GraphQL shape |
+| `graphql_get_account_info.json` | Account discovery GraphQL shape (`getAccountInfo` defaults) |
+| `graphql_get_account_info_two_accounts_one_default.json` | Multi-account login where only the group default is returned |
+| `graphql_get_account_detail_list_two_accounts.json` | `getAccountDetailList(ALL_ACCTS)` rows used to complete discovery |
 
 ## Rules
 

--- a/tests/fixtures/auth/graphql_get_account_detail_list_two_accounts.json
+++ b/tests/fixtures/auth/graphql_get_account_detail_list_two_accounts.json
@@ -38,12 +38,10 @@
           "accounts": [
             {
               "accountNumber": "1122334455",
-              "encryptedAccountNumber": "<ENCRYPTED_ACCOUNT_NUMBER_PRIMARY>",
               "encryptedPersonId": "<ENCRYPTED_PERSON_ID>"
             },
             {
               "accountNumber": "9988776655",
-              "encryptedAccountNumber": "<ENCRYPTED_ACCOUNT_NUMBER_SECONDARY>",
               "encryptedPersonId": "<ENCRYPTED_PERSON_ID>"
             }
           ]

--- a/tests/fixtures/auth/graphql_get_account_detail_list_two_accounts.json
+++ b/tests/fixtures/auth/graphql_get_account_detail_list_two_accounts.json
@@ -13,6 +13,7 @@
     },
     "body": {
       "operationName": "getAccountDetailList",
+      "query": "query getAccountDetailList($params: AccountDetailListParams!) { getAccountDetailList(params: $params) { totalCount accounts { accountNumber encryptedPersonId } } }",
       "variables": {
         "params": {
           "accountStatus": "ACTIVE",

--- a/tests/fixtures/auth/graphql_get_account_detail_list_two_accounts.json
+++ b/tests/fixtures/auth/graphql_get_account_detail_list_two_accounts.json
@@ -1,0 +1,53 @@
+{
+  "name": "graphql_get_account_detail_list_two_accounts",
+  "source": "issue_20_getAccountDetailList_ALL_ACCTS_ACTIVE",
+  "request": {
+    "method": "POST",
+    "url": "https://apix.portlandgeneral.com/pge-graphql",
+    "headers": {
+      "Authorization": "Bearer <APIGEE_ACCESS_TOKEN>",
+      "aws_graphql_server": "graphql_server",
+      "Content-Type": "application/json",
+      "Origin": "https://portlandgeneral.com",
+      "Referer": "https://portlandgeneral.com/"
+    },
+    "body": {
+      "operationName": "getAccountDetailList",
+      "variables": {
+        "params": {
+          "accountStatus": "ACTIVE",
+          "groupId": "ALL_ACCTS",
+          "paging": {"limit": 50, "offset": 0},
+          "sort": {"direction": "ASC", "sort": "DEFAULT"},
+          "filter": {"filterBy": "", "operator": "STARTSWITH"}
+        }
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "cookies": [],
+    "body": {
+      "data": {
+        "getAccountDetailList": {
+          "totalCount": 2,
+          "accounts": [
+            {
+              "accountNumber": "1122334455",
+              "encryptedAccountNumber": "<ENCRYPTED_ACCOUNT_NUMBER_PRIMARY>",
+              "encryptedPersonId": "<ENCRYPTED_PERSON_ID>"
+            },
+            {
+              "accountNumber": "9988776655",
+              "encryptedAccountNumber": "<ENCRYPTED_ACCOUNT_NUMBER_SECONDARY>",
+              "encryptedPersonId": "<ENCRYPTED_PERSON_ID>"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/auth/graphql_get_account_info_two_accounts_one_default.json
+++ b/tests/fixtures/auth/graphql_get_account_info_two_accounts_one_default.json
@@ -1,0 +1,52 @@
+{
+  "name": "graphql_get_account_info_two_accounts_one_default",
+  "source": "issue_20_hypothesis_non_default_second_account",
+  "request": {
+    "method": "POST",
+    "url": "https://apix.portlandgeneral.com/pge-graphql",
+    "headers": {
+      "Authorization": "Bearer <APIGEE_ACCESS_TOKEN>",
+      "aws_graphql_server": "graphql_server",
+      "Content-Type": "application/json",
+      "Origin": "https://portlandgeneral.com",
+      "Referer": "https://portlandgeneral.com/"
+    },
+    "body": {
+      "operationName": "getAccountInfo",
+      "query": "query getAccountInfo($params: GetAccountInfoParams) { getAccountInfo(params: $params) { encryptedPersonId accountMeta { totalAccounts hasInactiveAccounts } groups { groupId numberOfAccounts isDefault defaultAccount { accountNumber encryptedAccountNumber encryptedPersonId } } } }",
+      "variables": {
+        "params": null
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "cookies": [],
+    "body": {
+      "data": {
+        "getAccountInfo": {
+          "encryptedPersonId": "<ENCRYPTED_PERSON_ID>",
+          "accountMeta": {
+            "totalAccounts": 2,
+            "hasInactiveAccounts": false
+          },
+          "groups": [
+            {
+              "groupId": "<GROUP_ID>",
+              "numberOfAccounts": 2,
+              "isDefault": true,
+              "defaultAccount": {
+                "accountNumber": "1122334455",
+                "encryptedAccountNumber": "<ENCRYPTED_ACCOUNT_NUMBER_PRIMARY>",
+                "encryptedPersonId": "<ENCRYPTED_PERSON_ID>"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/auth/login_chain.json
+++ b/tests/fixtures/auth/login_chain.json
@@ -19,7 +19,13 @@
       "order": 3,
       "name": "graphql_get_account_info",
       "fixture": "graphql_get_account_info.json",
-      "role": "Discover encryptedPersonId and accountNumber list"
+      "role": "Discover encryptedPersonId and defaultAccount numbers"
+    },
+    {
+      "order": 3.5,
+      "name": "graphql_get_account_detail_list",
+      "fixture": "graphql_get_account_detail_list_two_accounts.json",
+      "role": "Enumerate ACTIVE accounts (ALL_ACCTS); merge with getAccountInfo defaults"
     },
     {
       "order": 4,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#20](https://github.com/spencerthayer/homeassistant-pge/issues/20): credential setup failed with `account_not_found` for a second account number on the same login when that account was not any group's `defaultAccount`.

`getAccountInfo` only returns each group's `defaultAccount`. Discovery now also enumerates `getAccountDetailList(groupId=ALL_ACCTS, accountStatus=ACTIVE)` (gated when `accountMeta.totalAccounts` is already covered by defaults) and **merges** those account numbers with the defaults. Detail-list failures soft-fail so single-account flows never regress; MFA/CAPTCHA stay fail-closed.

## Version / HACS

- Integration version: **`0.9.12`** (not `9.10.0`; next PATCH after Latest `0.9.11`)
- New workflow: `.github/workflows/release.yml` — on push to `main`, if `v{manifest.version}` does not exist yet, creates that GitHub Release as Latest (HACS pickup)
- **Squash-and-merge of this PR is what publishes `v0.9.12`.** Do not merge until ready for that release.

## Test plan

- [x] Local discovery/config-flow tests
- [x] Prior CI green on discovery commits
- [ ] CI green on this version/workflow commit (`test` / `hassfest` / `hacs` / `prek`)
- [ ] After squash-merge: confirm `Release` workflow created https://github.com/spencerthayer/homeassistant-pge/releases/tag/v0.9.12
- [ ] Reporter UAT on both accounts

## Out of scope / notes

- Inactive accounts still omitted (`accountStatus: ACTIVE`)
- Detail-list paging limit remains 50

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00667-a36b-7f2e-8079-e6f05923a5f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00667-a36b-7f2e-8079-e6f05923a5f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

