### PR TITLE
style(panel): tariff-status spacing + View bill PDF button styling (v0.10.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Home Assistant custom integration for **Portland General Electric (PGE)** — im
 ### HACS (recommended)
 
 1. HACS → **⋯** → **Custom repositories**, add `https://github.com/spencerthayer/homeassistant-pge` with category **Integration**.
-2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.10.4`).
+2. Install **Portland General Electric Energy Usage** (version matches the latest GitHub Release, e.g. `0.10.5`).
 3. Restart Home Assistant.
 
 ### Manual

--- a/custom_components/pge_energy/const.py
+++ b/custom_components/pge_energy/const.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 DOMAIN = "pge_energy"
-VERSION = "0.10.4"
+VERSION = "0.10.5"
 PLATFORMS = ["sensor", "binary_sensor"]
 
 # Custom panel (registered once per HA instance, not per entry).

--- a/custom_components/pge_energy/frontend/charts.js
+++ b/custom_components/pge_energy/frontend/charts.js
@@ -9,13 +9,13 @@ import {
   formatSignedUsd,
   projectDirectionalUsage,
   symmetricExtent,
-} from "./data.js?v=0.10.4";
+} from "./data.js?v=0.10.5";
 import {
   chromeColors,
   seriesColors,
   tooltipTheme,
   withAlpha,
-} from "./theme.js?v=0.10.4";
+} from "./theme.js?v=0.10.5";
 
 export { seriesColors };
 

--- a/custom_components/pge_energy/frontend/pge-panel.js
+++ b/custom_components/pge_energy/frontend/pge-panel.js
@@ -49,7 +49,7 @@ import {
   todHolidays,
   todPeriodForPacific,
   todWeekDays,
-} from "./data.js?v=0.10.4";
+} from "./data.js?v=0.10.5";
 import {
   createBarChart,
   createLineChart,
@@ -59,9 +59,9 @@ import {
   destroyCharts,
   renderHeatmap,
   seriesColors,
-} from "./charts.js?v=0.10.4";
-import { sparklineSvg } from "./svg-helpers.js?v=0.10.4";
-import { applyPanelTheme } from "./theme.js?v=0.10.4";
+} from "./charts.js?v=0.10.5";
+import { sparklineSvg } from "./svg-helpers.js?v=0.10.5";
+import { applyPanelTheme } from "./theme.js?v=0.10.5";
 
 /** @type {Record<string, string>} */
 export const PANEL_SECTION_ANCHORS = {
@@ -697,6 +697,30 @@ details.diagnostics summary { cursor: pointer; font-weight: 600; margin-bottom: 
   .entity-row { flex-wrap: wrap; gap: 4px 12px; }
 }
 
+  /* ---- Bill PDF ---- */
+  .bill-pdf-header .button {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 6px 14px; border-radius: 8px;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+    background: transparent;
+    font-size: 0.85rem; font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background 180ms ease,
+      box-shadow 180ms ease;
+  }
+  .bill-pdf-header .button::after { content: "↗"; font-size: 0.9em; opacity: 0.75; }
+  .bill-pdf-header .button:hover,
+  .bill-pdf-header .button:focus-visible {
+    background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--primary-text-color) 10%, transparent);
+  }
+  .bill-pdf-header .button:active {
+    background: color-mix(in srgb, var(--primary-color) 22%, transparent);
+  }
+
   /* ---- Time of Day hub (#tod) ---- */
   .tod-header { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-bottom: 12px; }
   .tod-source { font-size: 0.78rem; }
@@ -796,6 +820,7 @@ details.diagnostics summary { cursor: pointer; font-weight: 600; margin-bottom: 
   .tod-range { margin: 0 0 12px; }
   .tod-range-caption { margin: 0; flex: 1 1 100%; font-size: 0.85rem; }
   .tod-range .range-label { font-size: 0.82rem; color: var(--secondary-text-color); }
+  details.tariff-status-block { margin-top: 20px; }
 `;
 
 class PgeEnergyPanel extends HTMLElement {

--- a/custom_components/pge_energy/manifest.json
+++ b/custom_components/pge_energy/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "pypdf==6.14.2"
   ],
-  "version": "0.10.4"
+  "version": "0.10.5"
 }

--- a/tasks.md
+++ b/tasks.md
@@ -176,6 +176,12 @@
 - [x] HITL merge PR #18; HACS release `v0.9.0` published (`e2597ca`)
 - [x] v0.9.1: remove nonexistent speculative TOD pricing op (see Programs / TOD section above)
 
+## Panel styling polish — v0.10.5 (PATCH)
+
+- [x] `#tod` Tariff sources block spacing: `details.tariff-status-block` margin-top 20px
+- [x] Bill statement header: style `View bill PDF` link (`bill-pdf-header .button`) as themed outline button with hover/focus/active + external-link arrow
+- [x] VERSION bump `0.10.4 → 0.10.5` synced (const.py / manifest.json / frontend `?v=` / README); panel tests green; live HA verified serving new CSS
+
 ## Active agents
 
 - None


### PR DESCRIPTION
## Summary

PATCH release **0.10.5** — panel styling polish only, no behavior/data changes.

- `#tod`: add `margin-top: 20px` spacing above the **Tariff sources** collapsible (`details.tariff-status-block`)
- Billing statement header: style the previously-unstyled **View bill PDF** link (`bill-pdf-header .button`) as a themed outline button — primary-color border/text, rounded corners, hover/focus tint, active press state, external-link arrow; uses HA theme tokens (light/dark/custom safe)
- Version bump `0.10.4 → 0.10.5` synced across `const.py`, `manifest.json`, frontend `?v=` imports, README

## Verification

- `node --check pge-panel.js` clean
- Panel/tod source-assertion tests pass (12/12)
- Live HA at 127.0.0.1:8123 restarted and serving new CSS at `?v=0.10.5`
